### PR TITLE
fix(ci): decode google-services.json from a GitHub Secret on release runs

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -14,6 +14,7 @@
 #   ANDROID_KEY_ALIAS                 key alias inside the keystore
 #   ANDROID_KEY_PASSWORD              key password
 #   PLAY_SERVICE_ACCOUNT_JSON_BASE64  base64 of the Play Console service account JSON
+#   GOOGLE_SERVICES_JSON_BASE64       base64 of the Firebase google-services.json
 
 name: Android Release
 
@@ -77,6 +78,15 @@ jobs:
           mkdir -p "$RUNNER_TEMP/secrets"
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/secrets/keystore.jks"
           echo "${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}" | base64 -d > "$RUNNER_TEMP/secrets/play.json"
+
+      - name: Decode google-services.json
+        # Firebase config consumed by the `com.google.gms.google-services`
+        # Gradle plugin during processReleaseGoogleServices. Lives at
+        # composeApp/google-services.json (the canonical Firebase location)
+        # and is gitignored, so we decode it from a base64-encoded GitHub
+        # Secret on every run. Without this the Gradle release build fails
+        # before producing the AAB.
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 -d > composeApp/google-services.json
 
       - name: Render local.properties
         # The Gradle build reads signing config from local.properties. We

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -124,6 +124,7 @@ Repo → Settings → Secrets and variables → Actions → New repository secre
 | `ANDROID_KEY_ALIAS` | `local.properties:signing.keyAlias` | plain text |
 | `ANDROID_KEY_PASSWORD` | `local.properties:signing.keyPassword` | plain text |
 | `PLAY_SERVICE_ACCOUNT_JSON_BASE64` | Service account JSON downloaded from Google Cloud | `base64 -i path/to/play.json \| pbcopy` |
+| `GOOGLE_SERVICES_JSON_BASE64` | Firebase config (`composeApp/google-services.json`) | `base64 -i composeApp/google-services.json \| pbcopy` |
 
 The workflow base64-decodes the keystore + JSON into `$RUNNER_TEMP/secrets/`,
 which GitHub wipes after each job.

--- a/composeApp/fastlane/SETUP.md
+++ b/composeApp/fastlane/SETUP.md
@@ -85,6 +85,7 @@ Configure these under repo Settings → Secrets and variables → Actions:
 | `ANDROID_KEY_ALIAS` | Alias inside the keystore | plain text |
 | `ANDROID_KEY_PASSWORD` | Key password | plain text |
 | `PLAY_SERVICE_ACCOUNT_JSON_BASE64` | Play Console service account JSON | `base64 -i path/to/play.json \| pbcopy` |
+| `GOOGLE_SERVICES_JSON_BASE64` | Firebase config (`composeApp/google-services.json`) | `base64 -i composeApp/google-services.json \| pbcopy` |
 
 The workflow base64-decodes the keystore + JSON into `$RUNNER_TEMP/secrets/`,
 which GitHub wipes after the job ends.


### PR DESCRIPTION
## Summary

The v0.3.1 CI run failed at `processReleaseGoogleServices` because the
runner didn't have `composeApp/google-services.json`. That file is
gitignored (correctly — it embeds Firebase project identifiers and
should ship out-of-band like the keystore and the Play service account
JSON), but nobody was decoding it for CI.

This PR adds the same decode-from-base64 pattern we use for the keystore
and play.json. Decoded file lives at `composeApp/google-services.json`
(the canonical Firebase location); the Google Services Gradle plugin
finds it during the release build.

## Changes

- `.github/workflows/android-release.yml` — new step \"Decode google-services.json\" that runs before `Render local.properties`. Decodes from a new `GOOGLE_SERVICES_JSON_BASE64` secret. Header secrets list updated.
- `DEPLOY.md` and `composeApp/fastlane/SETUP.md` — secrets table now lists `GOOGLE_SERVICES_JSON_BASE64` with the encoding command.

## Operator action required (BEFORE merging)

Add the new GitHub Secret. From your local machine:

\`\`\`bash
base64 -i composeApp/google-services.json | pbcopy
\`\`\`

Then GitHub → Settings → Secrets and variables → Actions → New repository secret:
- Name: `GOOGLE_SERVICES_JSON_BASE64`
- Value: paste

## Operator action required (AFTER merging)

The v0.3.1 tag already exists; we don't need to re-tag. Trigger the
release manually:

GitHub → Actions → \"Android Release\" → \"Run workflow\":
- Branch: `main` (so the workflow uses the new YAML)
- Input `tag`: `v0.3.1`
- Click \"Run workflow\".

The job will check out v0.3.1's source code and apply the new YAML
(which now decodes google-services.json). Build → upload to Production
as DRAFT → roll out from Play Console.

## Why this is a good moment to test rebase-and-merge

This PR is small (3 files, +12 lines) and low-risk. Recommended to use
**\"Rebase and merge\"** in the merge button (instead of \"Squash and
merge\") so we get a chance to verify the new strategy on a small change
before adopting it for the next release.

## Test plan
- [x] `./gradlew :composeApp:processReleaseGoogleServices` passes locally with the existing local file.
- [ ] After merge + secret setup: workflow_dispatch v0.3.1 → completes → AAB lands in Play Console as draft.