### PR TITLE
fix(ci): use modern `inputs.tag` context for workflow_dispatch

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -33,7 +33,7 @@ concurrency:
   # Serialise releases — two tag pushes back-to-back must not race for the
   # same versionCode on Play. The group is per-tag so unrelated tags run in
   # parallel.
-  group: android-release-${{ github.event.inputs.tag || github.ref_name }}
+  group: android-release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -49,7 +49,7 @@ jobs:
           # On workflow_dispatch the ref defaults to the workflow file's
           # branch — explicitly check out the requested tag instead so the
           # AAB is built from the tagged commit.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Set up JDK 17
@@ -112,7 +112,7 @@ jobs:
           SUPPLY_JSON_KEY: ${{ runner.temp }}/secrets/play.json
           # On workflow_dispatch the auto-set GITHUB_REF_NAME is the workflow
           # branch, not the tag — override it so the lane parses correctly.
-          GITHUB_REF_NAME: ${{ github.event.inputs.tag || github.ref_name }}
+          GITHUB_REF_NAME: ${{ inputs.tag || github.ref_name }}
         run: bundle exec fastlane android release_from_tag
 
       - name: Upload AAB as workflow artifact
@@ -121,7 +121,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: composeApp-release-${{ github.event.inputs.tag || github.ref_name }}
+          name: composeApp-release-${{ inputs.tag || github.ref_name }}
           path: composeApp/build/outputs/bundle/release/composeApp-release.aab
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

Three consecutive `workflow_dispatch` runs (#3, #4, #5) failed with
\"Tag 'main' is not in form\" even when the operator filled `v0.3.1` into
the tag input and selected `Branch: main`. The cause is that
`\${{ github.event.inputs.tag }}` is evaluating to empty in this scenario,
so the `|| github.ref_name` fallback returns `main` (the dispatch
branch).

The fix is to switch to the modern `inputs.tag` context (introduced in
March 2022 and the recommended way to access `workflow_dispatch` inputs).
It's type-aware and properly resolves to the user-supplied value.

## Changes

- `.github/workflows/android-release.yml` — replace all four
  occurrences of `github.event.inputs.tag` with `inputs.tag`:
  - `concurrency.group`
  - `actions/checkout` `ref`
  - `GITHUB_REF_NAME` env var passed to fastlane
  - `actions/upload-artifact` `name`

For tag-push triggers (`on: push: tags`), `inputs.tag` is null, so the
`||` fallback keeps producing the correct value (`github.ref_name` =
the tag itself).

## How to test after merging

1. Merge this with **Rebase and merge** (small, low-risk PR).
2. GitHub → Actions → \"Android Release\" → \"Run workflow\":
   - **Use workflow from**: `Branch: main`
   - **Existing tag to (re)release**: `v0.3.1`
   - Click **Run workflow**.
3. The new run should resolve `inputs.tag = v0.3.1` correctly, parse the
   tag in the Fastfile, build the AAB and upload to Play Console as
   draft.

If for any reason it still fails on tag parsing, we'll add a debug step
that prints the resolved value before fastlane runs.